### PR TITLE
Bumped version numbers. Fixed JSR94 error

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ name := "ScalaDroolsDummyProject"
 
 version := "3"
 
-scalaVersion := "2.11.2"
+scalaVersion := "2.11.7"
 
 mainClass in assembly := Some("dummy.Dummy")
 
@@ -30,7 +30,7 @@ libraryDependencies ++= Seq(
     "drools-jsr94",
     "drools-decisiontables",
     "knowledge-api"
-).map("org.drools" % _ % "6.1.0.Final")
+).map("org.drools" % _ % "6.3.0.Final")
 
 
 libraryDependencies ++= Seq(
@@ -60,5 +60,7 @@ libraryDependencies ++= {
 initialCommands in console := """import dummy._"""
 
 resolvers += "jboss-releases" at "https://repository.jboss.org/nexus/content/repositories/releases"
+
+resolvers += "jboss-jsr94" at "http://repository.jboss.org/nexus/content/groups/public-jboss"
 
 resolvers += "sonatype-public" at "https://oss.sonatype.org/content/groups/public"


### PR DESCRIPTION
Redhat has moved some of their repos around. This resulted in
the project not being able to find the jsr94 jar.

I added an additional resolver as fix.

Here's a copy of the error generated by SBT : 

[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: jsr94#jsr94;1.1: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]
[warn]  Note: Unresolved dependencies path:
[warn]      jsr94:jsr94:1.1
[warn]        +- org.drools:drools-jsr94:6.3.0.Final (/Users/stephan/IdeaProjects/scala-drools-dummy-project/build.sbt#L27-34)
[warn]        +- scaladroolsdummyproject:scaladroolsdummyproject_2.11:3
[trace] Stack trace suppressed: run last *:update for the full output.
[error](*:update) sbt.ResolveException: unresolved dependency: jsr94#jsr94;1.1: not found
[error] Total time: 268 s, completed Oct 17, 2015 10:38:42 AM
